### PR TITLE
Fixes issue #3: plugin download url now no longer has pg included

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -2,10 +2,10 @@
 <plugin_manifest xmlns="http://www.elgg.org/plugin_manifest/1.8">
 	<name>Community Web Services</name>
 	<author>Core developers</author>
-	<version>1.9</version>
+	<version>1.9.1</version>
 	<description>Provides web services for use on the Elgg community site.</description>
 	<website>https://github.com/Elgg/community_web_services</website>
-	<copyright>(C) Elgg core developers 2011-2013</copyright>
+	<copyright>(C) Elgg core developers 2011-2014</copyright>
 	<license>GNU General Public License version 2</license>
 	<requires>
 		<type>elgg_release</type>

--- a/start.php
+++ b/start.php
@@ -71,7 +71,7 @@ function community_ws_plugin_check($plugins, $version) {
 				if ($plugin_require == $elgg_version) {
 					$new_release = $newer_releases[$index];
 					$dl_link = elgg_get_config('wwwroot');
-					$dl_link .= "pg/plugins/download/{$new_release->getGUID()}";
+					$dl_link .= "plugins/download/{$new_release->getGUID()}";
 
 					$info = new stdClass();
 					$info->plugin_id = $plugin_hash;


### PR DESCRIPTION
Reported in issue #3. With this fix the reply on a plugins.update.check no longer contains the "pg" handler in the download url.
